### PR TITLE
README Example URL is now stats.idre.ucla.edu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ Example
     import pandas as pd
     from gspread_pandas import Spread
 
-    file_name = "http://www.ats.ucla.edu/stat/data/binary.csv"
+    file_name = "http://stats.idre.ucla.edu/stat/data/binary.csv"
     df = pd.read_csv(file_name)
 
     # 'Example Spreadsheet' needs to already exist and your user must have access to it


### PR DESCRIPTION
The Example was broken (pd.read_csv throws an exception) because the previous URL fails with a 301. This can be seen by visiting it:

```
$ curl 'http://www.ats.ucla.edu/stat/data/binary.csv'
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://stats.idre.ucla.edu/">here</a>.</p>
</body></html>
```

This change simply substitutes the correct URL, and now the DataFrame read is fine.